### PR TITLE
fix tuple empty error when module is disabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   enabled = module.this.enabled
 
-  s3_arn_prefix = "arn:${one(data.aws_partition.default[*].partition)}:s3:::"
+  s3_arn_prefix = local.enabled ? "arn:${one(data.aws_partition.default[*].partition)}:s3:::" : null
 
   is_vpc = var.vpc_id != null
 


### PR DESCRIPTION
## what
* data source used in local value returns an empty tuple

## why
* Terraform errors out with empty tuple error, caused by data source is disabled correctly, but not taken care of in locals value where it is being used.

## references
* [Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). ](https://github.com/cloudposse/terraform-aws-transfer-sftp/issues/30)

