### PR TITLE
feat: allow to attach multiple policies to sftp user role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -219,9 +219,14 @@ resource "aws_iam_role" "s3_access_for_sftp_users" {
   name = module.iam_label[each.value.user_name].id
 
   assume_role_policy  = join("", data.aws_iam_policy_document.assume_role_policy[*].json)
-  managed_policy_arns = [aws_iam_policy.s3_access_for_sftp_users[each.value.user_name].arn]
 
   tags = module.this.tags
+}
+
+resource "aws_iam_role_policy_attachment" "s3_access_for_sftp_users" {
+  for_each = aws_iam_policy.s3_access_for_sftp_users
+  role = aws_iam_role.s3_access_for_sftp_users[each.key].name
+  policy_arn = each.value.arn
 }
 
 resource "aws_iam_policy" "logging" {


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
This PR aims to allow users of this module to add additional policies to the SFTP user role.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
This change is driven by the need to use a S3 bucket that encrypts files with a CMK (SSE-KMS).

As IAM role uses [managed_policy_arns](https://github.com/cloudposse/terraform-aws-transfer-sftp/blob/main/main.tf#L222), policy attachments are exclusive and no additional permissions can be added to this role.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
