### PR TITLE
Add output for endpoint_details

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,7 @@ output "s3_access_role_arns" {
   description = "Role ARNs for the S3 access"
   value       = { for user, val in aws_iam_role.s3_access_for_sftp_users : user => val.arn }
 }
+
+output "endpoint_details" {
+  value = module.this.enabled ? one(aws_transfer_server.default.*.endpoint_details) : null
+}


### PR DESCRIPTION
## what
Added an output to be able to access the endpoint_details

## why

In my use case I am managing my DNS elsewhere in my Terraform code and need to be able to access the VPC endpoint created for the transfer server so I can subsequently create DNS entries. This new output allows me to dynamically know the id of the VPC endpoint and thus lookup it's DNS names for use in creating CNAME's in my own DNS domain.