### PR TITLE
Bump Module Versions for Examples

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -8,7 +8,7 @@ provider "awsutils" {
 
 module "s3_bucket" {
   source  = "cloudposse/s3-bucket/aws"
-  version = "2.0.3"
+  version = "3.1.1"
 
   for_each = toset(["home", "extra"])
 

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -4,8 +4,8 @@ variable "region" {
 
 variable "sftp_users" {
   type = map(object({
-    user_name  = string,
-    public_key = string,
+    user_name          = string,
+    public_key         = string,
     bucket_permissions = optional(list(string))
   }))
   description = "The value which will be passed to the example module"

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,5 +1,6 @@
 variable "region" {
-  type = string
+  type        = string
+  description = "AWS Region where resources will be created"
 }
 
 variable "sftp_users" {

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -5,7 +5,8 @@ variable "region" {
 variable "sftp_users" {
   type = map(object({
     user_name  = string,
-    public_key = string
+    public_key = string,
+    bucket_permissions = optional(list(string))
   }))
   description = "The value which will be passed to the example module"
 }

--- a/examples/vpc/main.tf
+++ b/examples/vpc/main.tf
@@ -11,7 +11,7 @@ module "vpc" {
   source  = "cloudposse/vpc/aws"
   version = "2.1.0"
 
-  cidr_block = var.cidr_block
+  ipv4_primary_cidr_block = var.cidr_block
 
   context = module.this.context
 }

--- a/examples/vpc/main.tf
+++ b/examples/vpc/main.tf
@@ -9,7 +9,7 @@ provider "awsutils" {
 
 module "vpc" {
   source  = "cloudposse/vpc/aws"
-  version = "1.1.0"
+  version = "2.1.0"
 
   cidr_block = var.cidr_block
 
@@ -18,7 +18,7 @@ module "vpc" {
 
 module "subnets" {
   source  = "cloudposse/dynamic-subnets/aws"
-  version = "2.0.2"
+  version = "2.3.0"
 
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
@@ -33,7 +33,7 @@ module "subnets" {
 
 module "security_group" {
   source  = "cloudposse/security-group/aws"
-  version = "1.0.1"
+  version = "2.0.0"
 
   vpc_id = module.vpc.vpc_id
   rules = [
@@ -51,7 +51,7 @@ module "security_group" {
 
 module "s3_bucket" {
   source             = "cloudposse/s3-bucket/aws"
-  version            = "2.0.3"
+  version            = "3.1.1"
   acl                = "private"
   enabled            = true
   user_enabled       = false

--- a/examples/vpc/variables.tf
+++ b/examples/vpc/variables.tf
@@ -15,7 +15,8 @@ variable "cidr_block" {
 variable "sftp_users" {
   type = map(object({
     user_name  = string,
-    public_key = string
+    public_key = string,
+    bucket_permissions = optional(list(string))
   }))
   description = "The value which will be passed to the example module"
 }

--- a/examples/vpc/variables.tf
+++ b/examples/vpc/variables.tf
@@ -1,5 +1,6 @@
 variable "region" {
-  type = string
+  type        = string
+  description = "AWS Region where resources will be created"
 }
 
 variable "availability_zones" {
@@ -14,8 +15,8 @@ variable "cidr_block" {
 
 variable "sftp_users" {
   type = map(object({
-    user_name  = string,
-    public_key = string,
+    user_name          = string,
+    public_key         = string,
     bucket_permissions = optional(list(string))
   }))
   description = "The value which will be passed to the example module"

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ resource "aws_transfer_user" "default" {
   user_name = each.value.user_name
 
   home_directory_type = coalesce(each.value.home_directory_type, var.restricted_home ? "LOGICAL" : "PATH")
-  home_directory      = var.restricted_home ? null : (
+  home_directory = var.restricted_home ? null : (
     coalesce(
       each.value.home_directory,
       "/${coalesce(each.value.s3_bucket_name, var.s3_bucket_name)}"

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ locals {
   user_names_map = {
     for user, val in var.sftp_users :
     user => merge(val, {
-      s3_bucket_arn = coalesce("${local.s3_arn_prefix}${val.s3_bucket_name}", one(data.aws_s3_bucket.landing[*].arn))
+      s3_bucket_arn = val.s3_bucket_name != null ? "${local.s3_arn_prefix}${val.s3_bucket_name}" : one(data.aws_s3_bucket.landing[*].arn)
     })
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -5,8 +5,6 @@ locals {
 
   is_vpc = var.vpc_id != null
 
-  user_names = keys(var.sftp_users)
-
   user_names_map = {
     for user, val in var.sftp_users :
     user => merge(val, {
@@ -43,7 +41,7 @@ resource "aws_transfer_server" "default" {
       subnet_ids             = var.subnet_ids
       security_group_ids     = var.vpc_security_group_ids
       vpc_id                 = var.vpc_id
-      address_allocation_ids = var.eip_enabled ? aws_eip.sftp.*.id : var.address_allocation_ids
+      address_allocation_ids = var.eip_enabled ? aws_eip.sftp[*].id : var.address_allocation_ids
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -159,7 +159,7 @@ data "aws_iam_policy_document" "s3_access_for_sftp_users" {
     sid    = "HomeDirObjectAccess"
     effect = "Allow"
 
-    actions = [
+    actions = lookup(each.value, "bucket_permissions", null) != null ? lookup(each.value, "bucket_permissions") : [
       "s3:PutObject",
       "s3:GetObject",
       "s3:DeleteObject",

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,12 +5,12 @@ output "id" {
 
 output "transfer_endpoint" {
   description = "The endpoint of the Transfer Server"
-  value       = module.this.enabled ? join("", aws_transfer_server.default.*.endpoint) : null
+  value       = module.this.enabled ? join("", aws_transfer_server.default[*].endpoint) : null
 }
 
 output "elastic_ips" {
   description = "Provisioned Elastic IPs"
-  value       = module.this.enabled && var.eip_enabled ? aws_eip.sftp.*.id : null
+  value       = module.this.enabled && var.eip_enabled ? aws_eip.sftp[*].id : null
 }
 
 output "s3_access_role_arns" {

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "domain" {
 variable "sftp_users" {
   type        = any
   default     = {}
-  description = "List of SFTP usernames and public keys. The keys `user_name`, `public_key` are required. The keys `s3_bucket_name` are optional."
+  description = "List of SFTP usernames and public keys. The keys `user_name`, `public_key` are required. The keys `s3_bucket_name` and `bucket_permissions` are optional."
 }
 
 variable "restricted_home" {

--- a/variables.tf
+++ b/variables.tf
@@ -5,9 +5,20 @@ variable "domain" {
 }
 
 variable "sftp_users" {
-  type        = any
+  type = map(object({
+    user_name           = string
+    public_key          = string
+    s3_bucket_name      = optional(string)
+    bucket_permissions  = optional(list(string))
+    home_directory_type = optional(string)
+    home_directory      = optional(string)
+    home_directory_mappings = optional(list(object({
+      entry  = string
+      target = string
+    })))
+  }))
   default     = {}
-  description = "List of SFTP usernames and public keys. The keys `user_name`, `public_key` are required. The keys `s3_bucket_name` and `bucket_permissions` are optional."
+  description = "Map of SFTP users and their configurations. Required: user_name, public_key. Optional: s3_bucket_name, bucket_permissions, home_directory_type, home_directory, home_directory_mappings"
 }
 
 variable "restricted_home" {

--- a/variables.tf
+++ b/variables.tf
@@ -52,12 +52,6 @@ variable "subnet_ids" {
   default     = []
 }
 
-variable "vpc_endpoint_id" {
-  type        = string
-  description = "The ID of the VPC endpoint. This property can only be used when endpoint_type is set to VPC_ENDPOINT"
-  default     = null
-}
-
 variable "security_policy_name" {
   type        = string
   description = "Specifies the name of the security policy that is attached to the server. Possible values are TransferSecurityPolicy-2018-11, TransferSecurityPolicy-2020-06, and TransferSecurityPolicy-FIPS-2020-06. Default value is: TransferSecurityPolicy-2018-11."


### PR DESCRIPTION
## what
- Bump module versions used in examples

## why
- We need terratests to pass. They were previously using old versions of the modules that have deprecated usages

## references
- https://github.com/cloudposse/terraform-aws-transfer-sftp/actions/runs/13037133380/job/36370265805#step:12:738