### PR TITLE
Add additional outputs for the transfer service

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ output "id" {
 
 output "transfer_endpoint" {
   description = "The endpoint of the Transfer Server"
-  value       = module.this.enabled ? join("", aws_transfer_server.default[*].endpoint) : null
+  value       = module.this.enabled ? one(aws_transfer_server.default[*].endpoint) : null
 }
 
 output "elastic_ips" {
@@ -19,6 +19,16 @@ output "s3_access_role_arns" {
 }
 
 output "endpoint_details" {
-  value       = module.this.enabled ? one(aws_transfer_server.default[*].endpoint_details) : null
   description = "Endpoints details"
+  value       = module.this.enabled ? one(aws_transfer_server.default[*].endpoint_details) : null
+}
+
+output "arn" {
+  description = "ARN of the created Transfer Server"
+  value       = module.this.enabled ? one(aws_transfer_server.default[*].arn) : null
+}
+
+output "host_key_fingerprint" {
+  description = "The message-digest algorithm (MD5) hash of the Transfer Server's host key"
+  value       = module.this.enabled ? one(aws_transfer_server.default[*].host_key_fingerprint) : null
 }


### PR DESCRIPTION
## what

This adds additional outputs to expose the arn and host_key_fingerprint.

## why

I need these outputs for my workflows.

## references

This was previously opened under https://github.com/cloudposse/terraform-aws-transfer-sftp/pull/40, but the bot killed that PR.  This version has been rebased and should be ready to go.
This also has 2 minor nit-pick fixes:
 - Use the `one` function instead of a `join("", ...)` to make the output match all other outputs in this module.
 - reorders the value/description attributes in one resource to make the order match the others.