### PR TITLE
AWS provider 6 support (aws_eip)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -102,7 +102,7 @@ resource "aws_transfer_ssh_key" "default" {
 resource "aws_eip" "sftp" {
   count = local.enabled && var.eip_enabled ? length(var.subnet_ids) : 0
 
-  vpc = local.is_vpc
+  domain = "vpc"
 
   tags = module.this.tags
 }


### PR DESCRIPTION
## what
This PR makes it possible to use the module with the latest version of the AWS provider (version 6)

## why
`aws_eip` no longer supports a `vpc` argument. It needs to be changed to `domain`

Causes this error when running `terraform`

```
│ Error: Unsupported argument
│ 
│   on .terraform/modules/sftp/main.tf line 105, in resource "aws_eip" "sftp":
│  105:   vpc = local.is_vpc
│ 
│ An argument named "vpc" is not expected here.
```

## references
closes #78 
