### PR TITLE
feat: add pre and post authentication login banner support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,15 +26,15 @@ data "aws_s3_bucket" "landing" {
 resource "aws_transfer_server" "default" {
   count = local.enabled ? 1 : 0
 
-  identity_provider_type            = "SERVICE_MANAGED"
-  protocols                         = ["SFTP"]
-  domain                            = var.domain
-  endpoint_type                     = local.is_vpc ? "VPC" : "PUBLIC"
-  force_destroy                     = var.force_destroy
-  security_policy_name              = var.security_policy_name
-  logging_role                      = join("", aws_iam_role.logging[*].arn)
-  pre_authentication_login_banner   = var.pre_authentication_login_banner
-  post_authentication_login_banner  = var.post_authentication_login_banner
+  identity_provider_type           = "SERVICE_MANAGED"
+  protocols                        = ["SFTP"]
+  domain                           = var.domain
+  endpoint_type                    = local.is_vpc ? "VPC" : "PUBLIC"
+  force_destroy                    = var.force_destroy
+  security_policy_name             = var.security_policy_name
+  logging_role                     = join("", aws_iam_role.logging[*].arn)
+  pre_authentication_login_banner  = var.pre_authentication_login_banner
+  post_authentication_login_banner = var.post_authentication_login_banner
 
   dynamic "endpoint_details" {
     for_each = local.is_vpc ? [1] : []

--- a/main.tf
+++ b/main.tf
@@ -26,13 +26,15 @@ data "aws_s3_bucket" "landing" {
 resource "aws_transfer_server" "default" {
   count = local.enabled ? 1 : 0
 
-  identity_provider_type = "SERVICE_MANAGED"
-  protocols              = ["SFTP"]
-  domain                 = var.domain
-  endpoint_type          = local.is_vpc ? "VPC" : "PUBLIC"
-  force_destroy          = var.force_destroy
-  security_policy_name   = var.security_policy_name
-  logging_role           = join("", aws_iam_role.logging[*].arn)
+  identity_provider_type            = "SERVICE_MANAGED"
+  protocols                         = ["SFTP"]
+  domain                            = var.domain
+  endpoint_type                     = local.is_vpc ? "VPC" : "PUBLIC"
+  force_destroy                     = var.force_destroy
+  security_policy_name              = var.security_policy_name
+  logging_role                      = join("", aws_iam_role.logging[*].arn)
+  pre_authentication_login_banner   = var.pre_authentication_login_banner
+  post_authentication_login_banner  = var.post_authentication_login_banner
 
   dynamic "endpoint_details" {
     for_each = local.is_vpc ? [1] : []

--- a/variables.tf
+++ b/variables.tf
@@ -86,3 +86,15 @@ variable "eip_enabled" {
   description = "Whether to provision and attach an Elastic IP to be used as the SFTP endpoint. An EIP will be provisioned per subnet."
   default     = false
 }
+
+variable "pre_authentication_login_banner" {
+  type        = string
+  description = "Specify a string to display when users connect to a server. This string is displayed before the user authenticates. The SFTP protocol does not support post-authentication display banners."
+  default     = null
+}
+
+variable "post_authentication_login_banner" {
+  type        = string
+  description = "Specify a string to display when users connect to a server. This string is displayed after the user authenticates. The SFTP protocol does not support post-authentication display banners."
+  default     = null
+}


### PR DESCRIPTION
This code was partially generated by Windsurf.

## What

Add support for `pre_authentication_login_banner` and `post_authentication_login_banner` parameters on the AWS Transfer Server resource.

## Why

These banners allow displaying messages to users before and after authentication, which is useful for:
- Compliance requirements (legal notices)
- Security warnings (e.g., "Authorised Personnel only! If you proceed, all actions will be monitored.")
- User guidance

## Changes

### `variables.tf`
- Added `pre_authentication_login_banner` variable (string, default: null)
- Added `post_authentication_login_banner` variable (string, default: null)

### `main.tf`
- Added both banner parameters to the `aws_transfer_server` resource

## References

- Closes #80
- [AWS Transfer Server Terraform Resource - pre_authentication_login_banner](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/transfer_server#pre_authentication_login_banner)
- [AWS Documentation - Display banners](https://docs.aws.amazon.com/transfer/latest/userguide/configuring-servers-view-info.html)

## Testing

The changes are minimal and follow the existing patterns in the module. The new variables default to `null`, which means no banner will be displayed unless explicitly configured (backward compatible).